### PR TITLE
`alertId` in `TransactionEvent` can be `null`

### DIFF
--- a/packages/actions/src/actions.ts
+++ b/packages/actions/src/actions.ts
@@ -86,7 +86,7 @@ export interface TransactionEvent extends Event {
     /**
      * If event was created from alert.
      */
-    alertId?: string
+    alertId?: string | null
 }
 
 /**


### PR DESCRIPTION
AlertId returns `null` for an AlertEvent from this tx hash: `0x91b64b7935b98366381c33a519655b3d769f0a7b054011828387fe6ca08fbb98`