### PR TITLE
🐛 gateways: handle nullish config

### DIFF
--- a/packages/actions-test/src/gateways.ts
+++ b/packages/actions-test/src/gateways.ts
@@ -11,4 +11,8 @@ export class TestGateways implements Gateways {
         const gatewayConfig = this.gatewayConfig.get(name ?? "")
         return `https://${network}.gateway.tenderly.co/${gatewayConfig?.accessKey}`
     }
+
+    setConfig(name: string, config: any) {
+        this.gatewayConfig.set(name, config)
+    }
 }

--- a/packages/actions-test/src/gateways.ts
+++ b/packages/actions-test/src/gateways.ts
@@ -9,6 +9,6 @@ export class TestGateways implements Gateways {
 
     getGateway(network: Network, name?: string | undefined): string {
         const gatewayConfig = this.gatewayConfig.get(name ?? "")
-        return `https://${network}.gateway.tenderly.co/${gatewayConfig.accessKey}`
+        return `https://${network}.gateway.tenderly.co/${gatewayConfig?.accessKey}`
     }
 }

--- a/packages/actions-test/src/runtime.ts
+++ b/packages/actions-test/src/runtime.ts
@@ -1,4 +1,4 @@
-import {ActionFn, Context, Event, Gateways} from "@tenderly/actions";
+import {ActionFn, Context, Event} from "@tenderly/actions";
 import {TestSecrets} from "./secrets";
 import {TestStorage} from "./storage";
 import { TestGateways } from "./gateways";
@@ -6,7 +6,7 @@ import { TestGateways } from "./gateways";
 export class TestContext implements Context {
     secrets: TestSecrets;
     storage: TestStorage;
-    gateways: Gateways;
+    gateways: TestGateways;
 
     constructor() {
         this.secrets = new TestSecrets();


### PR DESCRIPTION
error:
```log
TypeError: Cannot read properties of undefined (reading 'accessKey')
 at TestGateways.getGateway (node_modules/@tenderly/actions-test/src/gateways.ts:12:72)
 at exports.default (actions/onMarketUpdate.ts:47:8)
 at async TestRuntime.execute (node_modules/@tenderly/actions-test/src/runtime.ts:26:9)
 at async Context.<anonymous> (test/onMarketUpdate.spec.ts:34:5)
```